### PR TITLE
Refactor: User 도메인 타입 변경

### DIFF
--- a/src/main/java/com/kdt/firststep/user/controller/HomeController.java
+++ b/src/main/java/com/kdt/firststep/user/controller/HomeController.java
@@ -1,0 +1,52 @@
+package com.kdt.firststep.user.controller;
+
+import com.kdt.firststep.community.domain.Post;
+import com.kdt.firststep.counselor.domain.CounselorProfile;
+import com.kdt.firststep.user.dto.response.BestPostResponseDTO;
+import com.kdt.firststep.user.dto.response.CounselorContentSummaryResponseDTO;
+import com.kdt.firststep.user.service.HomeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+
+@RestController
+@RequestMapping("/home")
+public class HomeController {
+
+    private final HomeService homeService;
+
+
+    @Autowired
+    public HomeController(HomeService homeService) {
+        this.homeService = homeService;
+    }
+
+    // Top 5 베스트 상담사 가져오기 API
+    //  CounselorProfile 엔티티에서 직접
+    @GetMapping("/top5Counselor")
+    public ResponseEntity<List<CounselorProfile>> getTop5CounselorByReviews() {
+        List<CounselorProfile> top5Counselors = homeService.getTop5CounselorsByReviews();
+        return ResponseEntity.ok(top5Counselors);
+    }
+
+    // 베스트 게시글 3개 가져오기
+    // BestPostResponseDTO를 통해서 가져옴.
+    @GetMapping("/bestPost")
+    public ResponseEntity<List<BestPostResponseDTO>> getBestPosts() {
+        List<BestPostResponseDTO> bestPosts = homeService.getBestPostByLikes();
+        return ResponseEntity.ok(bestPosts);
+    }
+
+
+    //상담사 콘텐츠 불러오기 API (상담사 콘텐츠 불러오기(제목, postId, 좋아요순 2개 최신순 2개))
+    @GetMapping("/counselorContent")
+    public ResponseEntity<List<CounselorContentSummaryResponseDTO>> getCounselorContents() {
+        List<CounselorContentSummaryResponseDTO> content = homeService.getCounselorContentByLikesAndRecent();
+        return ResponseEntity.ok(content);
+    }
+}

--- a/src/main/java/com/kdt/firststep/user/domain/User.java
+++ b/src/main/java/com/kdt/firststep/user/domain/User.java
@@ -9,12 +9,15 @@ import java.time.LocalDate;
 @Getter
 @Setter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "user")
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private int user_id;
+    @Column(name = "user_id")
+    private int userId;
 
     @Column(name = "user_name", nullable = false)
     private String userName;

--- a/src/main/java/com/kdt/firststep/user/domain/User.java
+++ b/src/main/java/com/kdt/firststep/user/domain/User.java
@@ -11,24 +11,24 @@ import java.time.LocalDate;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "user")
+@Table(name = "users")
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
-    private int userId;
+    private long userId;
 
-    @Column(name = "user_name", nullable = false)
+    @Column(name = "user_name")
     private String userName;
 
-    @Column(nullable = false)
+    @Column
     private String nickname;
 
-    @Column(nullable = false)
+    @Column
     private String email;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     private LocalDate birth;
@@ -45,13 +45,13 @@ public class User {
     @Column(name = "mode_type")
     private boolean modeType;
 
-    @Column(name = "personality_check", nullable = false)
+    @Column(name = "personality_check")
     private boolean personalityCheck;
 
-    @Column(name = "couple_check", nullable = false)
+    @Column(name = "couple_check")
     private boolean coupleCheck;
 
-    @Column(name = "counselor_check", nullable = false)
+    @Column(name = "counselor_check")
     private boolean counselorCheck;
 
     @Lob
@@ -60,7 +60,7 @@ public class User {
 
     private int coin;
 
-    @Column(name = "marital_status", nullable = false)
+    @Column(name = "marital_status")
     private boolean maritalStatus;
 
 }

--- a/src/main/java/com/kdt/firststep/user/dto/response/BestPostResponseDTO.java
+++ b/src/main/java/com/kdt/firststep/user/dto/response/BestPostResponseDTO.java
@@ -1,0 +1,16 @@
+package com.kdt.firststep.user.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BestPostResponseDTO {
+
+    private Long postId;
+    private String title;
+    private String content;
+}

--- a/src/main/java/com/kdt/firststep/user/dto/response/CounselorContentSummaryResponseDTO.java
+++ b/src/main/java/com/kdt/firststep/user/dto/response/CounselorContentSummaryResponseDTO.java
@@ -1,0 +1,18 @@
+package com.kdt.firststep.user.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CounselorContentSummaryResponseDTO {
+    private Long postId;
+    private String title;
+    private String writerName;
+    private int likes;
+
+
+}

--- a/src/main/java/com/kdt/firststep/user/dto/response/Top5CounselorResponseDTO.java
+++ b/src/main/java/com/kdt/firststep/user/dto/response/Top5CounselorResponseDTO.java
@@ -1,0 +1,17 @@
+package com.kdt.firststep.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Top5CounselorResponseDTO {
+        private Long counselorId;
+        private String name;
+        private double averageRating;
+
+}

--- a/src/main/java/com/kdt/firststep/user/repository/CounselorRepository.java
+++ b/src/main/java/com/kdt/firststep/user/repository/CounselorRepository.java
@@ -1,0 +1,20 @@
+package com.kdt.firststep.user.repository;
+
+import com.kdt.firststep.counselor.domain.CounselorProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface CounselorRepository extends JpaRepository<CounselorProfile, Long> {
+
+    // CounselorProfile과 CounselingReview를 조인
+    // 상담사별 평균 리뷰 점수를 계산하고 점수가 높은 순으로 상위 5명 가져옴.
+    @Query("SELECT cp FROM CounselorProfile cp " +
+        "JOIN CounselingReservation crv ON crv.counselor.id = cp.id " +
+        "JOIN CounselingReview cr ON cr.reservation.id = crv.id " +
+        "GROUP BY cp.id " +
+        "ORDER BY AVG(cr.rating) DESC")
+    List<CounselorProfile> findTopCounselorsByAverageRating();
+
+}

--- a/src/main/java/com/kdt/firststep/user/repository/PostRepository.java
+++ b/src/main/java/com/kdt/firststep/user/repository/PostRepository.java
@@ -1,0 +1,34 @@
+package com.kdt.firststep.user.repository;
+
+import com.kdt.firststep.community.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+    // post 테이블에서 좋아요 수(likes) 순으로 상위 3개의 게시글의 제목과 내용 일부만 가져오기.
+    @Query("SELECT p.postId, p.title, SUBSTRING(p.content, 1, 30) AS content " +
+        "FROM Post p " +
+        "ORDER BY p.likes DESC")
+    List<Object[]> findTop3ByLikesWithTitleAndContent();
+
+    /*
+     * {
+     * [postId: "1"
+     * title: "최신 글 순으로 가져온 첫 번째 게시글 "],
+     * [ postId: "2"
+     * title: "최신 글 순으로 가져온 첫 번째 게시글 "]
+     * }
+     *
+     * */
+    // post 테이블에서 category가 false인 것 중에서 최신 등록일(registerDate) 순으로 상위 2개의 게시글 가져오기
+    List<Post> findTop2ByCategoryFalseOrderByRegisterDateDesc();
+
+    // post 테이블에서 category가 false인 것 중에서 좋아요 수(likes) 순으로 상위 2개의 게시글 가져오기
+    // category가 false인 것 중에서 좋아요 수(likes) 순으로 상위 2개의 게시글 가져오기
+    List<Post> findTop2ByCategoryFalseOrderByLikesDesc();
+}
+
+

--- a/src/main/java/com/kdt/firststep/user/service/HomeService.java
+++ b/src/main/java/com/kdt/firststep/user/service/HomeService.java
@@ -1,0 +1,19 @@
+package com.kdt.firststep.user.service;
+
+import com.kdt.firststep.counselor.domain.CounselorProfile;
+import com.kdt.firststep.user.dto.response.BestPostResponseDTO;
+import com.kdt.firststep.user.dto.response.CounselorContentSummaryResponseDTO;
+import java.util.List;
+
+public interface HomeService {
+    //  CounselorRespoitory
+    // Top 5 베스트 상담사 가져오기(리뷰순) | /home/top5Counselor
+    List<CounselorProfile> getTop5CounselorsByReviews();
+
+    // PostRepository
+    // Top 3 베스트 커뮤니티 글 가져오기(좋아요순)
+    List<BestPostResponseDTO> getBestPostByLikes();
+
+    // 상담사 콘텐츠 불러오기(제목, postId, 좋아요순 2개 최신순 2개) | /home/counselorContent
+    List<CounselorContentSummaryResponseDTO> getCounselorContentByLikesAndRecent();
+}

--- a/src/main/java/com/kdt/firststep/user/service/HomeServiceImpl.java
+++ b/src/main/java/com/kdt/firststep/user/service/HomeServiceImpl.java
@@ -1,0 +1,71 @@
+package com.kdt.firststep.user.service;
+
+
+import com.kdt.firststep.community.domain.Post;
+import com.kdt.firststep.counselor.domain.CounselorProfile;
+import com.kdt.firststep.user.dto.response.BestPostResponseDTO;
+import com.kdt.firststep.user.dto.response.CounselorContentSummaryResponseDTO;
+import com.kdt.firststep.user.repository.PostRepository;
+import com.kdt.firststep.user.repository.CounselorRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class HomeServiceImpl implements HomeService{
+
+    private final CounselorRepository counselorRepository;
+    private final PostRepository postRepository;
+
+    @Autowired
+    public HomeServiceImpl(CounselorRepository counselorRepository, PostRepository communityRepository) {
+        this.counselorRepository = counselorRepository;
+        this.postRepository = communityRepository;
+    }
+
+    // Top 5 베스트 상담사 가져오기(리뷰순) | /home/top5Counselor
+    @Override
+    public List<CounselorProfile> getTop5CounselorsByReviews() {
+        return counselorRepository.findTop5CounselorsByAverageRating();
+    }
+
+    // /home/BestCommunity(일단은 5개만?)
+    // 필요한 거 : category, title, content -> 일단 다 String
+    @Override
+    public List<BestPostResponseDTO> getBestPostByLikes() {
+        List<Object[]> results = postRepository.findTop3ByLikesWithTitleAndContent();
+
+        // DTO로 변환
+        return results.stream()
+                    .map(result -> new BestPostResponseDTO(
+                        ((Number) result[0]).longValue(),  // postId
+                        (String) result[1],               // title
+                        (String) result[2]                // content (substring)
+                    ))
+                .collect(Collectors.toList());
+    }
+
+    // 상담사 콘텐츠 불러오기 (제목, postId, 좋아요 순 2개, 최신순 2개)
+    @Override
+    public List<CounselorContentSummaryResponseDTO> getCounselorContentByLikesAndRecent() {
+        List<Post> topLikes = postRepository.findTop2ByCategoryFalseOrderByLikesDesc();
+        List<Post> topRecent = postRepository.findTop2ByCategoryFalseOrderByRegisterDateDesc();
+
+        List<Post> combined = new ArrayList<>();
+        combined.addAll(topLikes);
+        combined.addAll(topRecent);
+
+        // Post 리스트를 CounselorContentResponseDTO 리스트로 변환
+        return combined.stream()
+            .map(post -> new CounselorContentSummaryResponseDTO(
+                post.getPostId(),
+                post.getTitle(),
+                post.getWriter().getUserName(),  // 작성자의 이름
+                post.getLikes()
+            ))
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/kdt/firststep/user/service/HomeServiceImpl.java
+++ b/src/main/java/com/kdt/firststep/user/service/HomeServiceImpl.java
@@ -7,6 +7,7 @@ import com.kdt.firststep.user.dto.response.BestPostResponseDTO;
 import com.kdt.firststep.user.dto.response.CounselorContentSummaryResponseDTO;
 import com.kdt.firststep.user.repository.PostRepository;
 import com.kdt.firststep.user.repository.CounselorRepository;
+import java.util.stream.Stream;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -29,8 +30,10 @@ public class HomeServiceImpl implements HomeService{
     // Top 5 베스트 상담사 가져오기(리뷰순) | /home/top5Counselor
     @Override
     public List<CounselorProfile> getTop5CounselorsByReviews() {
-        return counselorRepository.findTop5CounselorsByAverageRating();
-    }
+        return counselorRepository.findTopCounselorsByAverageRating()
+            .stream()
+            .limit(5)
+            .collect(Collectors.toList());    }
 
     // /home/BestCommunity(일단은 5개만?)
     // 필요한 거 : category, title, content -> 일단 다 String
@@ -54,16 +57,12 @@ public class HomeServiceImpl implements HomeService{
         List<Post> topLikes = postRepository.findTop2ByCategoryFalseOrderByLikesDesc();
         List<Post> topRecent = postRepository.findTop2ByCategoryFalseOrderByRegisterDateDesc();
 
-        List<Post> combined = new ArrayList<>();
-        combined.addAll(topLikes);
-        combined.addAll(topRecent);
-
-        // Post 리스트를 CounselorContentResponseDTO 리스트로 변환
-        return combined.stream()
+        // 두 리스트를 Stream으로 합쳐서 변환
+        return Stream.concat(topLikes.stream(), topRecent.stream())
             .map(post -> new CounselorContentSummaryResponseDTO(
                 post.getPostId(),
                 post.getTitle(),
-                post.getWriter().getUserName(),  // 작성자의 이름
+                post.getUserName(), // 작성자의 이름
                 post.getLikes()
             ))
             .collect(Collectors.toList());


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)  

  - [ ] 기능 추가
  - [ ] 기능 삭제
  - [ ] 버그 수정
  - [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
  - [ ] 문서 추가/수정
  - [x] 리팩토링

반영 브랜치

- Source: ex) feat/user/crud/chj
- Target: ex) dev

### 변경 사항
User 도메인 타입 변경 
- 기본 생성자의 경우 default 값이 `false`이기 때문에 nullable 삭제
- Table 이름을 `users`로 변경
- 엔티티 이름은 `User`로 유지

### 검증 여부

- [ ] Postman으로 API 테스트 완료
- [ ] 로컬에서 기능 정상 동작 확인
- [ ] 단위 테스트 작성 및 통과 확인
